### PR TITLE
Fix peak frequency bug in response grabbing for random cal solver

### DIFF
--- a/src/main/java/asl/sensor/experiment/RandomizedExperiment.java
+++ b/src/main/java/asl/sensor/experiment/RandomizedExperiment.java
@@ -52,6 +52,10 @@ public class RandomizedExperiment extends Experiment implements ParameterValidat
    * Defines the resolution of steps in iterative solution process
    */
   static final double DELTA = 1E-12;
+  /**
+   * Maximum possible frequency value as a multiple of nyquist (0.9).
+   * The solver will still default to 0.8 as results above that are very unstable for noisy cals
+   */
   private static final double PEAK_MULTIPLIER = InstrumentResponse.PEAK_MULTIPLIER;
   /**
    * Sets the default normalization point for curves (0.02 Hz)
@@ -79,7 +83,7 @@ public class RandomizedExperiment extends Experiment implements ParameterValidat
     isLowFrequencyCalibration = false;
     numIterations = 0;
     plotUsingHz = true;
-    nyquistMultiplier = PEAK_MULTIPLIER;
+    nyquistMultiplier = 0.8; // defaults to 0.8
   }
 
   /**

--- a/src/main/java/asl/sensor/experiment/RandomizedExperiment.java
+++ b/src/main/java/asl/sensor/experiment/RandomizedExperiment.java
@@ -259,7 +259,7 @@ public class RandomizedExperiment extends Experiment implements ParameterValidat
       minFreq = .2; // lower bound of .2 Hz (5s period) due to noise
       // get factor of nyquist rate, again due to noise
       maxFreq = nyquistMultiplier * nyquist;
-      maxPlotFreq = InstrumentResponse.PEAK_MULTIPLIER * nyquist; // i.e., 80% of nyquist
+      maxPlotFreq = PEAK_MULTIPLIER * nyquist; // i.e., 80% of nyquist
       // maxFreq = extFreq;
     }
 

--- a/src/main/java/asl/sensor/input/InstrumentResponse.java
+++ b/src/main/java/asl/sensor/input/InstrumentResponse.java
@@ -954,14 +954,10 @@ public class InstrumentResponse {
    * conjugate included in this vector in order to maintain constraints.
    *
    * @param lowFreq True if the low-frequency poles are to be fit
-   * @param nyquist Nyquist rate of data (upper bound on high-freq poles to fit)
+   * @param peak Peak frequency of zero to add to fit set (upper bound on high-freq poles to fit)
    * @return RealVector with fittable pole values
    */
-  public RealVector polesToVector(boolean lowFreq, double nyquist) {
-    // peak represents max value of poles we will fit; others are above rate of data
-    // and thus cannot be accurately determined from what we are solving for
-    double peak = PEAK_MULTIPLIER * nyquist;
-
+  public RealVector polesToVector(boolean lowFreq, double peak) {
     // create a list of doubles that are the non-conjugate elements from list
     // of poles, to convert to array and then vector format
     List<Double> componentList = new ArrayList<>();
@@ -1156,11 +1152,10 @@ public class InstrumentResponse {
    * conjugate included in this vector in order to maintain constraints.
    *
    * @param lowFreq True if the low-frequency zeros are to be fit
-   * @param nyquist Nyquist rate of data (upper bound on high-freq zeros to fit)
+   * @param peak Peak frequency of zero to add to fit set (upper bound on high-freq zeros to fit)
    * @return RealVector with fittable zero values
    */
-  public RealVector zerosToVector(boolean lowFreq, double nyquist) {
-    double peak = PEAK_MULTIPLIER * nyquist;
+  public RealVector zerosToVector(boolean lowFreq, double peak) {
 
     // create a list of doubles that are the non-conjugate elements from list
     // of poles, to convert to array and then vector format


### PR DESCRIPTION
Accidentally applied the peak maximum value twice in getting max frequency for input vector, causing too many poles and zeros to get filtered out. This is now fixed.