### PR TITLE
Ensure sorting of poles and zeros when loading RESP data

### DIFF
--- a/src/main/java/asl/sensor/experiment/RandomizedExperiment.java
+++ b/src/main/java/asl/sensor/experiment/RandomizedExperiment.java
@@ -52,6 +52,10 @@ public class RandomizedExperiment extends Experiment implements ParameterValidat
    * Defines the resolution of steps in iterative solution process
    */
   static final double DELTA = 1E-12;
+  /**
+   * Maximum possible frequency value as a multiple of nyquist (0.9).
+   * The solver will still default to 0.8 as results above that are very unstable for noisy cals
+   */
   private static final double PEAK_MULTIPLIER = InstrumentResponse.PEAK_MULTIPLIER;
   /**
    * Sets the default normalization point for curves (0.02 Hz)
@@ -79,7 +83,7 @@ public class RandomizedExperiment extends Experiment implements ParameterValidat
     isLowFrequencyCalibration = false;
     numIterations = 0;
     plotUsingHz = true;
-    nyquistMultiplier = PEAK_MULTIPLIER;
+    nyquistMultiplier = 0.8; // defaults to 0.8
   }
 
   /**

--- a/src/main/java/asl/sensor/experiment/RandomizedExperiment.java
+++ b/src/main/java/asl/sensor/experiment/RandomizedExperiment.java
@@ -259,7 +259,7 @@ public class RandomizedExperiment extends Experiment implements ParameterValidat
       minFreq = .2; // lower bound of .2 Hz (5s period) due to noise
       // get factor of nyquist rate, again due to noise
       maxFreq = nyquistMultiplier * nyquist;
-      maxPlotFreq = InstrumentResponse.PEAK_MULTIPLIER * nyquist; // i.e., 80% of nyquist
+      maxPlotFreq = PEAK_MULTIPLIER * nyquist; // i.e., 80% of nyquist
       // maxFreq = extFreq;
     }
 

--- a/src/main/java/asl/sensor/input/InstrumentResponse.java
+++ b/src/main/java/asl/sensor/input/InstrumentResponse.java
@@ -336,6 +336,9 @@ public class InstrumentResponse {
   }
 
   private static List<Pair<Complex, Integer>> setComponentValues(Complex[] pzArr) {
+    // other response code assumes all poles/zeros are listed in order of increasing magnitude
+    // (i.e., lower frequency poles/zeros are listed first, and then increasingly higher)
+    NumericUtils.complexMagnitudeSorter(pzArr);
     // first, sort matching P/Z values into bins, count up the number of each
     Map<Complex, Integer> values = new LinkedHashMap<>();
     for (Complex c : pzArr) {

--- a/src/main/java/asl/sensor/input/InstrumentResponse.java
+++ b/src/main/java/asl/sensor/input/InstrumentResponse.java
@@ -954,14 +954,10 @@ public class InstrumentResponse {
    * conjugate included in this vector in order to maintain constraints.
    *
    * @param lowFreq True if the low-frequency poles are to be fit
-   * @param nyquist Nyquist rate of data (upper bound on high-freq poles to fit)
+   * @param peak Peak frequency of zero to add to fit set (upper bound on high-freq poles to fit)
    * @return RealVector with fittable pole values
    */
-  public RealVector polesToVector(boolean lowFreq, double nyquist) {
-    // peak represents max value of poles we will fit; others are above rate of data
-    // and thus cannot be accurately determined from what we are solving for
-    double peak = PEAK_MULTIPLIER * nyquist;
-
+  public RealVector polesToVector(boolean lowFreq, double peak) {
     // create a list of doubles that are the non-conjugate elements from list
     // of poles, to convert to array and then vector format
     List<Double> componentList = new ArrayList<>();
@@ -1156,11 +1152,10 @@ public class InstrumentResponse {
    * conjugate included in this vector in order to maintain constraints.
    *
    * @param lowFreq True if the low-frequency zeros are to be fit
-   * @param nyquist Nyquist rate of data (upper bound on high-freq zeros to fit)
+   * @param peak Peak frequency of zero to add to fit set (upper bound on high-freq zeros to fit)
    * @return RealVector with fittable zero values
    */
-  public RealVector zerosToVector(boolean lowFreq, double nyquist) {
-    double peak = PEAK_MULTIPLIER * nyquist;
+  public RealVector zerosToVector(boolean lowFreq, double peak) {
 
     // create a list of doubles that are the non-conjugate elements from list
     // of poles, to convert to array and then vector format

--- a/src/main/java/asl/sensor/utils/NumericUtils.java
+++ b/src/main/java/asl/sensor/utils/NumericUtils.java
@@ -2,6 +2,7 @@ package asl.sensor.utils;
 
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import org.apache.commons.math3.complex.Complex;
@@ -45,9 +46,18 @@ public class NumericUtils {
    * Sort a list of complex values so that pure real numbers appear first.
    * The real and complex numbers are then each sorted according to their real
    * value, and then by their imaginary value.
+   * @param complexes A list of complex numbers to sort
    */
   public static void complexRealsFirstSorter(List<Complex> complexes) {
     complexes.sort(CpxRealComparator.instance);
+  }
+
+  /**
+   * Sort a list of complex values according to magnitude (i.e., period value).
+   * Pole and zero values are iterated through twi
+   */
+  public static void complexMagnitudeSorter(Complex[] complexes) {
+    Arrays.sort(complexes, CpxMagnitudeComparator.instance);
   }
 
   /**
@@ -275,6 +285,38 @@ public class NumericUtils {
     }
   }
 
+  /**
+   * Complex comparator ordering by magnitude.
+   *
+   * @author akearns
+   */
+  static class CpxMagnitudeComparator implements Comparator<Complex> {
+
+    static final CpxMagnitudeComparator instance = new CpxMagnitudeComparator();
+
+    private CpxMagnitudeComparator() {
+
+    }
+
+    @Override
+    public int compare(Complex c1, Complex c2) {
+
+      if (null == c1 && null == c2) {
+        return 0;
+      } else if (null == c1) {
+        return -1;
+      } else if (null == c2) {
+        return 1;
+      }
+
+      // assume
+      if (c1.getReal() == c2.getReal()) {
+        return (int) Math.signum(c1.getImaginary() - c2.getImaginary());
+      }
+
+      return (int) Math.signum(c1.abs() - c2.abs());
+    }
+  }
 }
 
 

--- a/src/test/java/asl/sensor/experiment/RandomizedExperimentTest.java
+++ b/src/test/java/asl/sensor/experiment/RandomizedExperimentTest.java
@@ -561,7 +561,7 @@ public class RandomizedExperimentTest {
       assertEquals(expectedPoles[i].getImaginary(), fitPoles.get(i).getImaginary(), 1E-5);
     }
 
-    assertEquals(197.1889105489712, rCal.getFitResidual(), 1E-7);
+    assertEquals(197.1889107001963, rCal.getFitResidual(), 1E-7);
     assertEquals(414.3706105547109, rCal.getInitResidual(), 1E-7);
   }
 

--- a/src/test/java/asl/sensor/input/InstrumentResponseTest.java
+++ b/src/test/java/asl/sensor/input/InstrumentResponseTest.java
@@ -134,10 +134,10 @@ public class InstrumentResponseTest {
       assertEquals(zrs, ir.getZeros());
 
       List<Complex> pls = new ArrayList<>();
-      pls.add(new Complex(-2.221000e-01, 2.221000e-01));
       pls.add(new Complex(-2.221000e-01, -2.221000e-01));
-      pls.add(new Complex(-3.918000e+01, 4.912000e+01));
+      pls.add(new Complex(-2.221000e-01, 2.221000e-01));
       pls.add(new Complex(-3.918000e+01, -4.912000e+01));
+      pls.add(new Complex(-3.918000e+01, 4.912000e+01));
       assertEquals(pls, ir.getPoles());
 
     } catch (IOException e) {
@@ -403,6 +403,31 @@ public class InstrumentResponseTest {
     }
   }
 
+  @Test
+  public void poleZerosMagnitudeIncreasing() throws IOException {
+    InstrumentResponse resp =
+        new InstrumentResponse(TestUtils.RESP_LOCATION + "STS6_Q330HR");
+    Complex[] poles = resp.getPoles().toArray(new Complex[]{});
+    Complex[] expected = {
+        new Complex(-1.23000e-02, -1.23000e-02),
+        new Complex(-1.23000e-02, +1.23000e-02),
+        new Complex(-1.36833e+02),
+        new Complex(-1.36833e+02),
+        new Complex(-1.21500e+02, -6.47000e+02),
+        new Complex(-1.21500e+02, +6.47000e+02),
+        new Complex(-7.64103e+02),
+        new Complex(-7.64103e+02),
+        new Complex(-7.64103e+02),
+        new Complex(-7.64103e+02),
+        new Complex(-7.64103e+02),
+        new Complex(-7.64103e+02),
+        new Complex(-1.04409e+10)
+    };
+    for (int i = 0; i < poles.length; ++i) {
+      assertTrue(Complex.equals(expected[i], poles[i], 1E-10));
+    }
+  }
+
   /**
    * This test tests that each field was parsed correctly and the correct epoch was parsed.
    */
@@ -437,10 +462,10 @@ public class InstrumentResponseTest {
     assertEquals(zeros, response.getZeros());
 
     List<Complex> poles = new ArrayList<>();
-    poles.add(new Complex(-11.234000e-02, 15.234000e-02));
     poles.add(new Complex(-11.234000e-02, -12.234000e-02));
-    poles.add(new Complex(-31.918000e+01, 5.912000e+01));
+    poles.add(new Complex(-11.234000e-02, 15.234000e-02));
     poles.add(new Complex(-31.918000e+01, -5.912000e+01));
+    poles.add(new Complex(-31.918000e+01, 5.912000e+01));
     assertEquals(poles, response.getPoles());
 
   }
@@ -476,8 +501,8 @@ public class InstrumentResponseTest {
     assertEquals(zeros, response.getZeros());
 
     List<Complex> poles = new ArrayList<>();
-    poles.add(new Complex(-2.234000e-02, 1.234000e-02));
     poles.add(new Complex(-2.234000e-02, -1.234000e-02));
+    poles.add(new Complex(-2.234000e-02, 1.234000e-02));
     poles.add(new Complex(-1.918000e+01, 4.912000e+01));
     assertEquals(poles, response.getPoles());
   }
@@ -512,8 +537,8 @@ public class InstrumentResponseTest {
     assertEquals(zeros, response.getZeros());
 
     List<Complex> poles = new ArrayList<>();
-    poles.add(new Complex(-2.234000e-02, 1.234000e-02));
     poles.add(new Complex(-2.234000e-02, -1.234000e-02));
+    poles.add(new Complex(-2.234000e-02, 1.234000e-02));
     poles.add(new Complex(-1.918000e+01, 4.912000e+01));
     assertEquals(poles, response.getPoles());
   }


### PR DESCRIPTION
Because finding poles and zeros for randomized cal fits expects that the data is in sorted order according to magnitude/frequency, a function to ensure sorting by magnitude now exists and is used when loading in resp files.