### PR TITLE
Add output to fit residual comparison test

### DIFF
--- a/src/test/java/asl/sensor/experiment/RandomizedExperimentTest.java
+++ b/src/test/java/asl/sensor/experiment/RandomizedExperimentTest.java
@@ -515,7 +515,7 @@ public class RandomizedExperimentTest {
       assertTrue(msg,fitAmp[i] <= expectedAmp[i] + 0.1);
     }
 
-    assertTrue(rCal.getFitResidual() < 51.);
+    assertTrue("Value of fit residual: " + rCal.getFitResidual(), rCal.getFitResidual() < 51.);
     assertEquals(1082.7313334829698, rCal.getInitResidual(), 1E-7);
   }
 


### PR DESCRIPTION
Used to determine cause of failing test (presumed to be related to issues around smoothing of data)