### PR TITLE
Enable parsing of responses with epochs with little-to-no time info

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'eclipse'
 apply plugin: 'idea'
 apply plugin: 'application'
 
-version = '1.4.2'
+version = '1.4.3'
 
 mainClassName = 'asl.sensor.SensorSuite'
 sourceCompatibility = '1.8'

--- a/src/test/java/asl/sensor/input/InstrumentResponseTest.java
+++ b/src/test/java/asl/sensor/input/InstrumentResponseTest.java
@@ -287,6 +287,13 @@ public class InstrumentResponseTest {
     assertEquals(expected, actual);
   }
 
+  @Test
+  public void parseTermAsDate_starttime_with_milliseconds() {
+    Instant actual = InstrumentResponse.parseTermAsDate("B052F23     End date:  2007,337,10:15:00.12345");
+    Instant expected = LocalDateTime.parse("2007-12-03T10:15:00").toInstant(ZoneOffset.UTC);
+    assertEquals(expected, actual);
+  }
+
 
   @Test
   public void parseTermAsComplex_checkThatComplexArrayWasOrderedCorrectly() {

--- a/src/test/java/asl/sensor/input/InstrumentResponseTest.java
+++ b/src/test/java/asl/sensor/input/InstrumentResponseTest.java
@@ -274,6 +274,13 @@ public class InstrumentResponseTest {
   }
 
   @Test
+  public void parseTermAsDate_starttime_no_time_component() {
+    Instant actual = InstrumentResponse.parseTermAsDate("B052F23     End date:  2007,337");
+    Instant expected = LocalDateTime.parse("2007-12-03T00:00:00").toInstant(ZoneOffset.UTC);
+    assertEquals(expected, actual);
+  }
+
+  @Test
   public void parseTermAsComplex_checkThatComplexArrayWasOrderedCorrectly() {
     Complex[] arr = new Complex[5];
     String[] lines = {"B053F15-18    0 -5.943130E+01  0.000000E+00  0.000000E+00  0.000000E+00",

--- a/src/test/java/asl/sensor/input/InstrumentResponseTest.java
+++ b/src/test/java/asl/sensor/input/InstrumentResponseTest.java
@@ -274,11 +274,19 @@ public class InstrumentResponseTest {
   }
 
   @Test
-  public void parseTermAsDate_starttime_no_time_component() {
+  public void parseTermAsDate_starttime_no_minutes() {
+    Instant actual = InstrumentResponse.parseTermAsDate("B052F23     End date:  2007,337,01");
+    Instant expected = LocalDateTime.parse("2007-12-03T01:00:00").toInstant(ZoneOffset.UTC);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void parseTermAsDate_starttime_no_hours() {
     Instant actual = InstrumentResponse.parseTermAsDate("B052F23     End date:  2007,337");
     Instant expected = LocalDateTime.parse("2007-12-03T00:00:00").toInstant(ZoneOffset.UTC);
     assertEquals(expected, actual);
   }
+
 
   @Test
   public void parseTermAsComplex_checkThatComplexArrayWasOrderedCorrectly() {


### PR DESCRIPTION
Responses built by ASL may truncate dates formatted like "2018,037,01:00:00" to just "2018,037" or "2015,210,00:00:00" to "2018,210". We should be able to handle responses without time information in their epochs (where the start is implicitly the start of the day) or with only partial time information (i.e., only hours or hours and minutes defined with others implicitly zero).