### PR TITLE
Enable user selection of angle reference data for gain experiment

### DIFF
--- a/src/main/java/asl/sensor/experiment/GainSixExperiment.java
+++ b/src/main/java/asl/sensor/experiment/GainSixExperiment.java
@@ -21,10 +21,15 @@ public class GainSixExperiment extends Experiment {
   private final int[] indices;
   // used to store the intermediate result data of each of N,S,V components (in that order)
   private GainExperiment[] componentBackends;
-  private double north2Angle, east2Angle;
+  private double northAngle, eastAngle;
+  private int indexOfAngleRefData;
+  // indexOfAngleRefData represents which set of data to use as fixed angle reference
+  // this can be either 0 (first NEZ set) or 1 (second)
 
   public GainSixExperiment() {
     super();
+
+    indexOfAngleRefData = 0; // default to first set of data
 
     componentBackends = new GainExperiment[DIMENSIONS];
     for (int i = 0; i < componentBackends.length; i++) {
@@ -46,24 +51,17 @@ public class GainSixExperiment extends Experiment {
     String[] dataStrings = new String[DIMENSIONS];
     dataStrings[0] = getResultString(0) +
         "\n" + "Estimated azimuth (deg): " +
-        DECIMAL_FORMAT.get().format(Math.toDegrees(north2Angle));
+        DECIMAL_FORMAT.get().format(Math.toDegrees(northAngle));
     dataStrings[1] = getResultString(1) +
         "\n" + "Estimated azimuth (deg): " +
-        DECIMAL_FORMAT.get().format(Math.toDegrees(east2Angle));
+        DECIMAL_FORMAT.get().format(Math.toDegrees(eastAngle));
     dataStrings[2] = getResultString(2);
     return dataStrings;
   }
 
   @Override
   public String[] getInsetStrings() {
-    String[] dataStrings = new String[DIMENSIONS];
-    // each dimensional component (n, s, v) has an inset string with formatted date info
-    // it is the only entry in its inset strings array, so we can just get that and add to
-    // the array we are returning, one for each plot
-    for (int i = 0; i < dataStrings.length; ++i) {
-      dataStrings[i] = componentBackends[i].getInsetStrings()[0];
-    }
-    return dataStrings;
+    return getDataStrings();
   }
 
   @Override
@@ -89,17 +87,26 @@ public class GainSixExperiment extends Experiment {
       }
     }
 
-    //first get the first set of data (NSV), then second
-    double[] north1Sensor = dataStore.getBlock(0).getData();
-    double[] east1Sensor = dataStore.getBlock(1).getData();
+    // get the data to perform pre-process rotation step
+    // note that data store index identifies dimension [N, E, Z]
+    // and block index identifies either first or second group of data
+    DataBlock northRef = stores[0].getBlock(indexOfAngleRefData);
+    DataBlock eastRef = stores[1].getBlock(indexOfAngleRefData);
+    double[] northRefSensor = northRef.getData();
+    double[] eastRefSensor = eastRef.getData();
 
-    double[] north2Sensor = dataStore.getBlock(3).getData();
-    double[] east2Sensor = dataStore.getBlock(4).getData();
+    // each dimension has 2 inputs, the rotation reference and to-rotate data
+    // if ref is 0, this will be 1; if ref is 1, this will be 0
+    int indexOfRotatingData = indexOfAngleRefData + 1 % 2;
+    DataBlock northRotate = stores[0].getBlock(indexOfRotatingData);
+    DataBlock eastRotate = stores[1].getBlock(indexOfRotatingData);
+    double[] northRotateSensor = northRotate.getData();
+    double[] east2Sensor = eastRotate.getData();
 
     // see also the rotation used in the 9-input self noise backend
     fireStateChange("Getting second north sensor orientation...");
-    north2Angle = -AzimuthExperiment.getAzimuth(north1Sensor, east1Sensor,
-        north2Sensor, interval, start, end);
+    northAngle = -AzimuthExperiment.getAzimuth(northRefSensor, eastRefSensor,
+        northRotateSensor, interval, start, end);
 
     fireStateChange("Getting second east sensor orientation...");
     // direction north angle should be if north and east truly orthogonal
@@ -108,17 +115,17 @@ public class GainSixExperiment extends Experiment {
     // azimuth of east sensor
     // offset by 3Pi/2 is the same as offset Pi/2 (90 degrees) in other
     // rotation direction
-    east2Angle = -AzimuthExperiment.getAzimuth(north1Sensor, east1Sensor,
+    eastAngle = -AzimuthExperiment.getAzimuth(northRefSensor, eastRefSensor,
         east2Sensor, interval, start, end) + (3 * Math.PI / 2);
 
     // now to rotate the data according to these angles
     fireStateChange("Rotating data...");
     DataBlock north2Rotated =
-        TimeSeriesUtils.rotate(dataStore.getBlock(3), dataStore.getBlock(4), north2Angle);
-    stores[0].setBlock(1, north2Rotated);
+        TimeSeriesUtils.rotate(northRotate, eastRotate, northAngle);
+    stores[0].setBlock(indexOfRotatingData, north2Rotated);
     DataBlock east2Rotated =
-        TimeSeriesUtils.rotateX(dataStore.getBlock(3), dataStore.getBlock(4), east2Angle);
-    stores[1].setBlock(1, east2Rotated);
+        TimeSeriesUtils.rotateX(northRotate, eastRotate, eastAngle);
+    stores[1].setBlock(indexOfRotatingData, east2Rotated);
 
     // now get the datasets to plug into the datastore
     String[] direction = new String[]{"north", "east", "vertical"};
@@ -139,7 +146,14 @@ public class GainSixExperiment extends Experiment {
       dataNames.addAll(componentBackend.getInputNames());
     }
 
+  }
 
+  public void setFirstDataAsAngleReference() {
+    indexOfAngleRefData = 0;
+  }
+
+  public void setSecondDataAsAngleReference() {
+    indexOfAngleRefData = 1;
   }
 
   @Override
@@ -157,7 +171,7 @@ public class GainSixExperiment extends Experiment {
    * @see TimeSeriesUtils#rotateX
    */
   public double getEastAzimuth() {
-    return east2Angle;
+    return eastAngle;
   }
 
 
@@ -180,7 +194,7 @@ public class GainSixExperiment extends Experiment {
    * @return Angle of second north sensor (radians)
    */
   public double getNorthAzimuth() {
-    return north2Angle;
+    return northAngle;
   }
 
   @Override

--- a/src/main/java/asl/sensor/gui/GainSixPanel.java
+++ b/src/main/java/asl/sensor/gui/GainSixPanel.java
@@ -7,7 +7,13 @@ import asl.sensor.input.DataStore;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
+import javax.swing.BoxLayout;
+import javax.swing.ButtonGroup;
 import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+import javax.swing.JTextArea;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.annotations.XYTitleAnnotation;
@@ -28,6 +34,8 @@ public class GainSixPanel extends GainPanel {
   private JFreeChart northChart;
   private JFreeChart eastChart;
   private JFreeChart verticalChart; // gain result per dimensional component
+  private JRadioButton firstRadioButton, secondRadioButton;
+
   /**
    * Instantiate the panel, including sliders and stat calc button
    */
@@ -43,6 +51,24 @@ public class GainSixPanel extends GainPanel {
       channelType[(3 * i) + 1] = "East sensor " + num + " (RESP required)";
       channelType[(3 * i) + 2] = "Vertical sensor " + num + " (RESP required)";
     }
+
+    firstRadioButton = new JRadioButton("first ");
+    firstRadioButton.setSelected(true);
+    secondRadioButton = new JRadioButton("second ");
+
+
+    ButtonGroup group = new ButtonGroup();
+    group.add(firstRadioButton);
+    group.add(secondRadioButton);
+
+    JPanel angleRefSelection = new JPanel();
+    angleRefSelection.setLayout(new BoxLayout(angleRefSelection, BoxLayout.X_AXIS));
+    angleRefSelection.add(new JLabel("Use the "));
+    angleRefSelection.add(firstRadioButton);
+    angleRefSelection.add(secondRadioButton);
+    angleRefSelection.add(new JLabel("input set as reference (requires regen)"));
+    angleRefSelection.setMaximumSize(angleRefSelection.getMinimumSize());
+    angleRefSelection.setPreferredSize(angleRefSelection.getMinimumSize());
 
     plotTheseInBold = new String[]{"NLNM"};
 
@@ -75,9 +101,14 @@ public class GainSixPanel extends GainPanel {
     constraints.anchor = GridBagConstraints.CENTER;
     this.add(chartPanel, constraints);
 
-    constraints.gridx = 0;
     constraints.gridy += 1;
     constraints.weighty = 0;
+    constraints.fill = GridBagConstraints.NONE;
+    this.add(angleRefSelection, constraints);
+
+    constraints.fill = GridBagConstraints.BOTH;
+    constraints.gridx = 0;
+    constraints.gridy += 1;
     constraints.gridwidth = 1;
     constraints.anchor = GridBagConstraints.EAST;
     this.add(leftSlider, constraints);
@@ -255,6 +286,13 @@ public class GainSixPanel extends GainPanel {
     set = true;
 
     setDataNames();
+    GainSixExperiment six = (GainSixExperiment) expResult;
+
+    if (firstRadioButton.isSelected())  {
+      six.setFirstDataAsAngleReference();
+    } else {
+      six.setSecondDataAsAngleReference();
+    }
 
     expResult.runExperimentOnData(dataStore);
 

--- a/src/test/java/asl/sensor/experiment/NoiseExperimentTest.java
+++ b/src/test/java/asl/sensor/experiment/NoiseExperimentTest.java
@@ -137,7 +137,7 @@ public class NoiseExperimentTest {
   public void testResultsData1PSD2() {
     int idx = 1;
     double psdCheck = -161.00;
-    double noiseCheck = -162.41;
+    double noiseCheck = -163.14;
     // everything below here same for every test
     XYSeriesCollection xysc = setUpTest1();
     // first 3 data, PSDs of each input
@@ -179,7 +179,7 @@ public class NoiseExperimentTest {
   public void testResultsData1PSD3() {
     int idx = 2;
     double psdCheck = -157.70;
-    double noiseCheck = -158.66;
+    double noiseCheck = -158.80;
     // everything below here same for every test
     XYSeriesCollection xysc = setUpTest1();
     // first 3 data, PSDs of each input
@@ -220,7 +220,7 @@ public class NoiseExperimentTest {
   public void testResultsData2PSD1() {
     int idx = 0;
     double psdCheck = -159.61;
-    double noiseCheck = -161.16;
+    double noiseCheck = -161.22;
     // everything below here same for every test
     XYSeriesCollection xysc = setUpTest2();
     // first 3 data, PSDs of each input


### PR DESCRIPTION
Adds a radio button to GUI to enable either first or second set of data to be used as reference angle for the gain experiment. Defaults to original behavior where the first data is used.