### PR TITLE
Fix issues with resp loading and saving when running gui

### DIFF
--- a/src/main/java/asl/sensor/gui/InputPanel.java
+++ b/src/main/java/asl/sensor/gui/InputPanel.java
@@ -355,12 +355,7 @@ public class InputPanel
         List<String> names = new ArrayList<>(respFilenames);
         Collections.sort(names);
         names.add("Load custom response...");
-        String[] nameArray = new String[names.size()];
-        for (int k = 0; k < nameArray.length; ++k) {
-          String name = names.get(k);
-          name = name.replace("resps/", "");
-          nameArray[k] = name;
-        }
+        String[] nameArray = names.toArray(new String[]{});
 
         int index = lastRespIndex;
         if (lastRespIndex < 0) {

--- a/src/main/java/asl/sensor/gui/ResponsePanel.java
+++ b/src/main/java/asl/sensor/gui/ResponsePanel.java
@@ -174,22 +174,28 @@ public class ResponsePanel extends ExperimentPanel {
           "RESP File Selection",
           JOptionPane.PLAIN_MESSAGE,
           null, names.toArray(),
-          names.get(names.size() - 1));
+          0);
+
+      // did user cancel operation?
+      if (result == null) {
+        return; // nothing left to do here, so let's close this out
+      }
 
       String resultStr = (String) result;
 
       try {
         // copy response file out of embedded set and into responses folder
-
         File respDir = new File("responses/");
         if (!respDir.exists()) {
           //noinspection ResultOfMethodCallIgnored
           respDir.mkdir();
         }
 
-        InputStream respStream = ResponsePanel.class.getResourceAsStream("/" + resultStr);
-        Path path = Paths.get(respDir.getCanonicalPath(), resultStr);
-        Files.copy(respStream, path, REPLACE_EXISTING);
+        ClassLoader cl = ResponsePanel.class.getClassLoader();
+        InputStream respStream =
+            cl.getResourceAsStream(InstrumentResponse.RESP_DIRECTORY + resultStr);
+        Path destinationPath = Paths.get(respDir.getCanonicalPath(), resultStr);
+        Files.copy(respStream, destinationPath, REPLACE_EXISTING);
 
       } catch (IOException e) {
         e.printStackTrace();
@@ -199,12 +205,10 @@ public class ResponsePanel extends ExperimentPanel {
 
   @Override
   protected void drawCharts() {
-
     plotSelection.setSelectedIndex(0);
     chart = magnitudeChart;
     chartPanel.setChart(chart);
     chartPanel.setMouseZoomable(true);
-
   }
 
   @Override

--- a/src/main/java/asl/sensor/input/InstrumentResponse.java
+++ b/src/main/java/asl/sensor/input/InstrumentResponse.java
@@ -39,6 +39,8 @@ import asl.sensor.utils.NumericUtils;
  */
 public class InstrumentResponse {
 
+  public static final String RESP_DIRECTORY = "resps/";
+
   /**
    * Maximum proportion of nyquist rate of a signal response to fit (as in RandomizedExperiment)
    */
@@ -137,7 +139,7 @@ public class InstrumentResponse {
       throws IOException {
 
     ClassLoader cl = InputPanel.class.getClassLoader();
-    InputStream is = cl.getResourceAsStream("resps/" + fname);
+    InputStream is = cl.getResourceAsStream(RESP_DIRECTORY + fname);
     BufferedReader fr = new BufferedReader(new InputStreamReader(is));
     return new InstrumentResponse(fr, fname);
   }
@@ -150,7 +152,7 @@ public class InstrumentResponse {
   public static Set<String> parseInstrumentList() {
     Set<String> respFilenames = new HashSet<>();
     ClassLoader cl = InstrumentResponse.class.getClassLoader();
-
+    // this requires the operation "gradle listResps" to be run first
     InputStream respRead = cl.getResourceAsStream("responses.txt");
     BufferedReader respBuff =
         new BufferedReader( new InputStreamReader(respRead) );


### PR DESCRIPTION
Trying to extract resps was causing NPEs. This has since been fixed. 