### PR TITLE
Fix issue where reference data index reset on backend processing (gain test)

### DIFF
--- a/src/main/java/asl/sensor/CalProcessingServer.java
+++ b/src/main/java/asl/sensor/CalProcessingServer.java
@@ -504,6 +504,9 @@ public class CalProcessingServer {
     gainSix.runExperimentOnData(ds);
 
     String[] dataStrings = gainSix.getDataStrings();
+    double northAzimuth = gainSix.getNorthAzimuthDegrees();
+    double eastAzimuth = gainSix.getEastAzimuthDegrees();
+    double[][] statistics = gainSix.getStatistics();
 
     List<XYSeriesCollection> results = gainSix.getData();
 
@@ -547,9 +550,11 @@ public class CalProcessingServer {
           RectangleAnchor.TOP_RIGHT);
       plot.addAnnotation(title);
 
+      BasicStroke stroke;
+
       // now, make everything thicker!
       for (int seriesIndex = 0; seriesIndex < timeseriesIn.getSeriesCount(); ++seriesIndex) {
-        BasicStroke stroke = (BasicStroke) plot.getRenderer().getSeriesStroke(seriesIndex);
+        stroke = (BasicStroke) plot.getRenderer().getSeriesStroke(seriesIndex);
         if (stroke == null) {
           stroke = (BasicStroke) plot.getRenderer().getBaseStroke();
         }
@@ -575,18 +580,11 @@ public class CalProcessingServer {
       // ensure that NLNM lines are bolder, colored black
       XYItemRenderer renderer = plot.getRenderer();
       // series index 0 - ref data; series index 1 - other data; series index 2 - NLNM plot
-      BasicStroke stroke = (BasicStroke) renderer.getSeriesStroke(2);
-      if (stroke == null) {
-        stroke = (BasicStroke) renderer.getBaseStroke();
-      }
+      stroke = (BasicStroke) plot.getRenderer().getBaseStroke();
       stroke = new BasicStroke(stroke.getLineWidth() * 2);
       renderer.setSeriesStroke(2, stroke);
       renderer.setSeriesPaint(2, new Color(0, 0, 0));
     }
-
-    double northAzimuth = gainSix.getNorthAzimuthDegrees();
-    double eastAzimuth = gainSix.getEastAzimuthDegrees();
-    double[][] statistics = gainSix.getStatistics();
 
     BufferedImage[] images = ReportingUtils.chartsToImageList(1, 1280, 960, charts);
     byte[][] pngByteArrays = new byte[images.length][];

--- a/src/main/java/asl/sensor/experiment/GainSixExperiment.java
+++ b/src/main/java/asl/sensor/experiment/GainSixExperiment.java
@@ -28,11 +28,13 @@ public class GainSixExperiment extends Experiment {
   private int indexOfAngleRefData;
   // indexOfAngleRefData represents which set of data to use as fixed angle reference
   // this can be either 0 (first NEZ set) or 1 (second)
+  private int indexOfGainRefData; // as above, but for which data to use as gain reference
 
   public GainSixExperiment() {
     super();
 
     indexOfAngleRefData = 0; // default to first set of data
+    indexOfGainRefData = 0;
 
     componentBackends = new GainExperiment[DIMENSIONS];
     for (int i = 0; i < componentBackends.length; i++) {
@@ -74,6 +76,7 @@ public class GainSixExperiment extends Experiment {
     for (int i = 0; i < componentBackends.length; i++) {
       componentBackends[i] = new GainExperiment();
     }
+    assignReferenceIndex(); // make sure the expected reference is used
 
     long interval = dataStore.getBlock(0).getInterval();
     long start = dataStore.getBlock(0).getStartTime();
@@ -260,8 +263,13 @@ public class GainSixExperiment extends Experiment {
    * @param newIndex Value of dataset to be chosen as reference for all gain estimations
    */
   public void setReferenceIndex(int newIndex) {
+    indexOfGainRefData = newIndex;
+    assignReferenceIndex();
+  }
+
+  private void assignReferenceIndex() {
     for (GainExperiment component : componentBackends) {
-      component.setReferenceIndex(newIndex);
+      component.setReferenceIndex(indexOfGainRefData);
     }
   }
 


### PR DESCRIPTION
Mainly an issue on ITT as the reference index was reset when data was processed on the GUI side