### PR TITLE
Fix sample rate mismatch issue causing calibrations to trigger OOB exception

### DIFF
--- a/src/main/java/asl/sensor/CalProcessingServer.java
+++ b/src/main/java/asl/sensor/CalProcessingServer.java
@@ -203,10 +203,11 @@ public class CalProcessingServer {
     ds.setBlock(0, calBlock);
     ds.setBlock(1, outBlock);
     ds.setResponse(1, ir);
-    ds.trim(start, end);
     if (lowFreq) {
       ds.resample(10.); // more than 5 Hz should be unnecessary for low-frequency curve fitting
     }
+    ds.trimToCommonTime();
+    ds.trim(start, end);
 
     return runExpGetDataRand(ds, lowFreq);
   }

--- a/src/main/java/asl/sensor/experiment/Experiment.java
+++ b/src/main/java/asl/sensor/experiment/Experiment.java
@@ -406,8 +406,6 @@ public abstract class Experiment {
       return;
     }
 
-    // TODO: may want to do a check that enough data exists and throw exception as necessary
-
     final DataBlock db = dataStore.getXthLoadedBlock(1);
 
     start = db.getStartTime();

--- a/src/main/java/asl/sensor/experiment/GainExperiment.java
+++ b/src/main/java/asl/sensor/experiment/GainExperiment.java
@@ -100,12 +100,15 @@ public class GainExperiment extends Experiment {
     // indices here is a linear array pointing to where
     // the data is in the passed-in data store, mainly to find relevant resps
 
+    int maxLength = Integer.MAX_VALUE;
+
     for (int i = 0; i < NUMBER_TO_LOAD; ++i) {
       // XthFullyLoaded starts at 1 (i.e., get first full-loaded), not 0
       int idx = dataStore.getXthFullyLoadedIndex(i + 1);
       indices[i] = idx;
       dataNames.add(dataStore.getBlock(idx).getName());
       dataNames.add(dataStore.getResponse(idx).getName());
+      maxLength = Math.min(maxLength, dataStore.getBlock(idx).size());
     }
 
     gainStage1 = new double[NUMBER_TO_LOAD];
@@ -129,7 +132,7 @@ public class GainExperiment extends Experiment {
       int idx = indices[i];
       String name = "PSD " + dataStore.getBlock(idx).getName() + " [" + idx + "]";
       XYSeries xys = new XYSeries(name);
-      fftResults[i] = dataStore.getPSD(idx);
+      fftResults[i] = dataStore.getPSD(idx, maxLength);
       Complex[] fft = fftResults[i].getFFT();
       double[] freqs = fftResults[i].getFreqs();
       // false, because we don't want to plot in frequency space

--- a/src/main/java/asl/sensor/experiment/NoiseExperiment.java
+++ b/src/main/java/asl/sensor/experiment/NoiseExperiment.java
@@ -76,11 +76,13 @@ public class NoiseExperiment extends Experiment {
     // get the first (index.length) seed/resp pairs. while we expect to
     // have the first three plots be the ones with loaded data, in general
     // it is probably better to keep the program flexible against valid input
+    int maxLength = Integer.MAX_VALUE;
     for (int i = 0; i < respIndices.length; ++i) {
       // xth fully loaded function begins at 1
       int idx = dataStore.getXthFullyLoadedIndex(i + 1);
       respIndices[i] = idx;
       dataNames.add(dataStore.getBlock(idx).getName());
+      maxLength = Math.min(maxLength, dataStore.getBlock(idx).size());
       dataNames.add(dataStore.getResponse(idx).getName());
     }
 
@@ -101,7 +103,7 @@ public class NoiseExperiment extends Experiment {
       fireStateChange("Getting PSDs of data " + (idx + 1) + "...");
       String name = "PSD " + dataStore.getBlock(idx).getName() + " [" + idx + "]";
       XYSeries powerSeries = new XYSeries(name);
-      FFTResult psdCalc = dataStore.getPSD(idx);
+      FFTResult psdCalc = dataStore.getPSD(idx, maxLength);
       Complex[] fft = psdCalc.getFFT();
       spectra[i] = fft;
       freqs = psdCalc.getFreqs();
@@ -113,17 +115,17 @@ public class NoiseExperiment extends Experiment {
     // spectra[i] is crosspower pii, now to get pij terms for i!=j
     fireStateChange(getting + "1 & 3");
     FFTResult fft =
-        FFTResult.crossPower(dataIn[0], dataIn[2], responses[0], responses[2]);
+        FFTResult.crossPower(dataIn[0], dataIn[2], responses[0], responses[2], maxLength);
     Complex[] c13 = fft.getFFT();
 
     fireStateChange(getting + "2 & 1");
     fft =
-        FFTResult.crossPower(dataIn[1], dataIn[0], responses[1], responses[0]);
+        FFTResult.crossPower(dataIn[1], dataIn[0], responses[1], responses[0], maxLength);
     Complex[] c21 = fft.getFFT();
 
     fireStateChange(getting + "2 & 3");
     fft =
-        FFTResult.crossPower(dataIn[1], dataIn[2], responses[1], responses[2]);
+        FFTResult.crossPower(dataIn[1], dataIn[2], responses[1], responses[2], maxLength);
     Complex[] c23 = fft.getFFT();
 
     // WIP: use PSD results to get noise at each point see spectra

--- a/src/main/java/asl/sensor/experiment/StepExperiment.java
+++ b/src/main/java/asl/sensor/experiment/StepExperiment.java
@@ -203,7 +203,8 @@ public class StepExperiment extends Experiment {
     // single sided FFT includes lowpass filter and demean in preprocessing
     // additional processing is done when inverting the FFT in the calculate method
     FFTResult sensorsFFT =
-        FFTResult.singleSidedFilteredFFT(sensorOutput, needsFlip);
+        FFTResult.
+            singleSidedFilteredFFT(sensorOutput, needsFlip);
     // these values used in calculating the response deconvolution
     sensorFFTSeries = sensorsFFT.getFFT();
     freqs = sensorsFFT.getFreqs();

--- a/src/main/java/asl/sensor/input/DataBlock.java
+++ b/src/main/java/asl/sensor/input/DataBlock.java
@@ -147,9 +147,7 @@ public class DataBlock {
 
     long timeCursor = trimmedStart;
 
-    int numPoints =
-        (int) Math.ceil((trimmedEnd - trimmedStart) / ((double) interval));
-
+    int numPoints = sizeNativeSampleRate();
     cachedTimeSeries = new double[numPoints];
     int lastFilledIndex = 0;
 
@@ -518,6 +516,18 @@ public class DataBlock {
     long timeDiff = trimmedEnd - trimmedStart;
     return (int) (timeDiff / targetInterval);
   }
+
+  /**
+   * Return the number of points in the given data range assuming the data does not require
+   * any level of decimation in order to be read in
+   *
+   * @return length of the data region to be returned, including filled-in gaps
+   */
+  int sizeNativeSampleRate() {
+    long timeDiff = trimmedEnd - trimmedStart;
+    return (int) (timeDiff / interval);
+  }
+
 
   /**
    * Converts this object's time series data into a form plottable by a chart.

--- a/src/main/java/asl/sensor/input/DataStore.java
+++ b/src/main/java/asl/sensor/input/DataStore.java
@@ -192,7 +192,29 @@ public class DataStore {
     double[] data = dataBlockArray[idx].getData();
     long interval = dataBlockArray[idx].getInterval();
     InstrumentResponse ir = responses[idx];
-    return FFTResult.crossPower(data, data, ir, ir, interval);
+    return FFTResult.crossPower(data, data, ir, ir, data.length, interval);
+  }
+
+  /**
+   * Gets the power-spectral density of an index in this object.
+   * If a PSD has already been calculated, this will return that. If not,
+   * it will calculate the result, store it, and then return that data.
+   *
+   * This version of the function is meant to be used in cases where exact length
+   * of the PSD must be specified in advance, such as when working with data that
+   * may have timing differences due to quantization that mean trimming makes
+   * some data be of different lengths from what is expected.
+   *
+   * @param idx Index of data to get the PSD of
+   * @param maxLength Maximum number of points to calculate PSD over -- range 0 to maxLength
+   * @return Complex array of frequency values and a
+   * double array of the frequencies
+   */
+  public FFTResult getPSD(int idx, int maxLength) {
+    double[] data = dataBlockArray[idx].getData();
+    long interval = dataBlockArray[idx].getInterval();
+    InstrumentResponse ir = responses[idx];
+    return FFTResult.crossPower(data, data, ir, ir, maxLength, interval);
   }
 
   /**

--- a/src/main/java/asl/sensor/input/DataStore.java
+++ b/src/main/java/asl/sensor/input/DataStore.java
@@ -292,12 +292,12 @@ public class DataStore {
     // first loop to get lowest-frequency data
     for (int i = 0; i < limit; ++i) {
       if (thisBlockIsSet[i]) {
-        interval = Math.max(interval, getBlock(i).getInitialInterval());
+        interval = Math.max(interval, getBlock(i).getInterval());
       }
     }
     // second loop to downsample
     for (int i = 0; i < limit; ++i) {
-      if (thisBlockIsSet[i] && getBlock(i).getInitialInterval() != interval) {
+      if (thisBlockIsSet[i] && getBlock(i).getInterval() != interval) {
         getBlock(i).resample(interval);
       }
     }

--- a/src/main/java/asl/sensor/utils/FFTResult.java
+++ b/src/main/java/asl/sensor/utils/FFTResult.java
@@ -508,7 +508,7 @@ public class FFTResult {
     }
 
     long interval = data1.getInterval();
-
+    System.out.println(list1.length +"," + list2.length);
     return spectralCalc(list1, list2, interval);
 
   }

--- a/src/main/java/asl/sensor/utils/FFTResult.java
+++ b/src/main/java/asl/sensor/utils/FFTResult.java
@@ -508,7 +508,6 @@ public class FFTResult {
     }
 
     long interval = data1.getInterval();
-    System.out.println(list1.length +"," + list2.length);
     return spectralCalc(list1, list2, interval);
 
   }

--- a/src/test/java/asl/sensor/input/DataBlockTest.java
+++ b/src/test/java/asl/sensor/input/DataBlockTest.java
@@ -1,5 +1,6 @@
 package asl.sensor.input;
 
+import static asl.sensor.test.TestUtils.getSeedFolder;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -20,6 +21,25 @@ public class DataBlockTest {
   private final String location = "00";
   private final String channel = "BH0";
   private final String fileID = station + "_" + location + "_" + channel + ".512.seed";
+
+  @Test
+  public void samplingMatchesData() {
+    String respName = "STS2gen3_Q330HR";
+    String dataFolderName = getSeedFolder("IU", "FUNA", "2019", "073");
+    String calName = dataFolderName + "_BC0.512.seed";
+    String sensOutName = dataFolderName + "00_BHZ.512.seed";
+
+    DataStore ds = DataStoreUtils.createFromNamesEmbedResp(respName, calName, sensOutName);
+    ds.trimToCommonTime();
+    ds.trim(1552589460000L, 1552603860000L);
+    ds.resample(10.);
+
+    assertEquals(288000, ds.getBlock(0).sizeNativeSampleRate());
+    assertEquals(576000, ds.getBlock(1).sizeNativeSampleRate());
+    assertEquals(144000, ds.getBlock(1).size());
+    assertEquals(ds.getBlock(1).getData().length, ds.getBlock(1).size());
+    assertEquals(ds.getBlock(0).size(), ds.getBlock(1).size());
+  }
 
   @Test
   public void trimsCorrectly() throws Exception {

--- a/src/test/java/asl/sensor/output/CalServerTest.java
+++ b/src/test/java/asl/sensor/output/CalServerTest.java
@@ -23,6 +23,21 @@ public class CalServerTest {
   private static final String folder = TestUtils.TEST_DATA_LOCATION + TestUtils.SUBPAGE;
 
   @Test
+  public void testRandomNoOOBException() throws SeedFormatException, CodecException, IOException {
+    String respName = "STS2gen3_Q330HR";
+    String dataFolderName = getSeedFolder("IU", "FUNA", "2019", "073");
+    String calName = dataFolderName + "_BC0.512.seed";
+    String sensOutName = dataFolderName + "00_BHZ.512.seed";
+    String startTime = "2019-03-14T18:51:00Z";
+    String endTime = "2019-03-14T22:51:00Z";
+
+    CalProcessingServer server = new CalProcessingServer();
+    server.runRand(calName, sensOutName, respName, true, startTime, endTime, true);
+
+    // now, do we get a null pointer exception?
+  }
+
+  @Test
   public void testRandomResults() throws SeedFormatException, CodecException, IOException {
     String respName = RESP_LOCATION + "RESP.IU.KIEV.00.BH1";
     String dataFolderName = getSeedFolder("IU", "KIEV", "2018", "044");
@@ -64,11 +79,6 @@ public class CalServerTest {
         expectedInitPoles[2],
         expectedInitPoles[3],
     };
-
-    for (int i = 0; i < fitPoles.length; i++) {
-      System.out.println(fitPoles[i] + ", " + expectedFitPoles[i]);
-    }
-
 
     assertEquals(expectedInitPoles.length, initPoles.length);
     assertEquals(expectedFitPoles.length, fitPoles.length);


### PR DESCRIPTION
Includes test cases to ensure decimation of data is at the correct sizes given specific values.
Additional fail-safes have been added to prevent regressions from data without matching sample rate values (i.e., downsampling data quantized on a different digitizers may produce lengths off by a sample or two depending on how close the data is to the specified region).