### PR TITLE
Add more detail to time range trim OOB exception message

### DIFF
--- a/src/main/java/asl/sensor/experiment/Experiment.java
+++ b/src/main/java/asl/sensor/experiment/Experiment.java
@@ -1,5 +1,6 @@
 package asl.sensor.experiment;
 
+import asl.sensor.utils.TimeSeriesUtils;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
@@ -54,12 +55,6 @@ public abstract class Experiment {
   // defines template pattern for each type of test, given by backend
   // each test returns new (set of) timeseries data from the input data
 
-  public static final ThreadLocal<SimpleDateFormat> DATE_TIME_FORMAT =
-      ThreadLocal.withInitial(() -> {
-        SimpleDateFormat format = new SimpleDateFormat("YYYY.DDD.HH:mm:ss.SSS");
-        format.setTimeZone(TimeZone.getTimeZone("UTC"));
-        return format;
-      });
   public static final ThreadLocal<DecimalFormat> DECIMAL_FORMAT =
       ThreadLocal.withInitial(() -> {
         DecimalFormat format = new DecimalFormat("#.###");
@@ -187,14 +182,11 @@ public abstract class Experiment {
    * @return formatted start time (Julian day)
    */
   String getFormattedStartDate() {
-    return "Data start time:\n" +
-            DATE_TIME_FORMAT.get().format(Date.from(Instant.ofEpochMilli(start)));
+    return "Data start time:\n" + TimeSeriesUtils.formatEpochMillis(start);
   }
 
   String getFormattedEndDate() {
-    return "Data end time:\n" +
-            DATE_TIME_FORMAT.get().format(Date.from(Instant.ofEpochMilli(end))) +
-            '\n';
+    return "Data end time:\n" + TimeSeriesUtils.formatEpochMillis(end) + '\n';
   }
 
   /**

--- a/src/main/java/asl/sensor/input/DataStore.java
+++ b/src/main/java/asl/sensor/input/DataStore.java
@@ -7,6 +7,7 @@ import edu.sc.seis.seisFile.mseed.SeedFormatException;
 import java.io.IOException;
 import java.time.Instant;
 import org.apache.commons.math3.util.Pair;
+import org.jfree.data.time.TimeSeries;
 
 /**
  * Holds the inputted data from miniSEED files both as a simple struct
@@ -556,7 +557,18 @@ public class DataStore {
       DataBlock db = getBlock(i);
 
       if (end < db.getStartTime() || start > db.getEndTime()) {
-        throw new IndexOutOfBoundsException("Time range invalid for some data");
+
+        String trimStartFormatted = TimeSeriesUtils.formatEpochMillis(start);
+        String trimEndFormatted = TimeSeriesUtils.formatEpochMillis(end);
+        String blockStartFormatted = TimeSeriesUtils.formatEpochMillis(db.getStartTime());
+        String blockEndFormatted = TimeSeriesUtils.formatEpochMillis(db.getEndTime());
+
+        String errMessage = "Trim range outside of valid data window for " + db.getName() + '\n'
+            + "Attempted to trim to range (" + trimStartFormatted
+            + ", " + trimEndFormatted + ")\n"
+            + "Data range is only from (" + blockStartFormatted
+            + ", " + blockEndFormatted + ")\n";
+        throw new IndexOutOfBoundsException(errMessage);
       }
 
       if (start < db.getStartTime()) {

--- a/src/main/java/asl/sensor/utils/TimeSeriesUtils.java
+++ b/src/main/java/asl/sensor/utils/TimeSeriesUtils.java
@@ -5,12 +5,16 @@ import java.io.EOFException;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 import org.apache.commons.math3.util.Pair;
 import asl.sensor.input.DataBlock;
 import edu.iris.dmc.seedcodec.CodecException;
@@ -43,6 +47,17 @@ public class TimeSeriesUtils {
 
   // divide by this to go from nanoseconds to milliseconds
   public static final int TO_MILLI_FACTOR = 1000000;
+
+  public static final ThreadLocal<SimpleDateFormat> DATE_TIME_FORMAT =
+      ThreadLocal.withInitial(() -> {
+        SimpleDateFormat format = new SimpleDateFormat("YYYY.DDD.HH:mm:ss.SSS");
+        format.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return format;
+      });
+
+  public static String formatEpochMillis(long millis) {
+    return DATE_TIME_FORMAT.get().format(Date.from(Instant.ofEpochMilli(millis)));
+  }
 
   /**
    * Merge arrays from multiple timeseries into a single object

--- a/src/test/java/asl/sensor/experiment/ExperimentTest.java
+++ b/src/test/java/asl/sensor/experiment/ExperimentTest.java
@@ -1,7 +1,7 @@
 package asl.sensor.experiment;
 
 import static asl.sensor.experiment.Experiment.DATE_FORMAT;
-import static asl.sensor.experiment.Experiment.DATE_TIME_FORMAT;
+import static asl.sensor.utils.TimeSeriesUtils.DATE_TIME_FORMAT;
 import static asl.sensor.experiment.Experiment.DECIMAL_FORMAT;
 import static asl.sensor.utils.TimeSeriesUtils.ONE_HZ_INTERVAL;
 import static junit.framework.TestCase.assertEquals;


### PR DESCRIPTION
This will make it easier to diagnose issues with malformed calibration data (such as IU CASY 2019 077 HF cal.)