### PR TITLE
Build now depends on java utils submodule

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,5 +116,5 @@ task gitSubmodule(type: Exec) {
     commandLine 'git', 'submodule', 'update', '--init', '--recursive'
 }
 
-build.dependsOn copyJar, copyServerJar
+build.dependsOn copyJar, copyServerJar, gitSubmodule
 processTestResources.dependsOn gitSubmodule


### PR DESCRIPTION
Necessary for automated test builds on server; was crashing due to lack of submodule updates