### PR TITLE
Fix resp embed loading error

### DIFF
--- a/src/main/java/asl/sensor/experiment/RandomizedExperiment.java
+++ b/src/main/java/asl/sensor/experiment/RandomizedExperiment.java
@@ -503,7 +503,7 @@ public class RandomizedExperiment extends Experiment implements ParameterValidat
       minFreq = .2; // lower bound of .2 Hz (5s period) due to noise
       // get factor of nyquist rate, again due to noise
       maxFreq = nyquistMultiplier * nyquist;
-      maxPlotFreq = PEAK_MULTIPLIER * nyquist; // i.e., 80% of nyquist
+      maxPlotFreq = PEAK_MULTIPLIER * nyquist; // always plot up to 90% of nyquist
       // maxFreq = extFreq;
     }
 

--- a/src/main/java/asl/sensor/gui/InputPanel.java
+++ b/src/main/java/asl/sensor/gui/InputPanel.java
@@ -315,13 +315,17 @@ public class InputPanel
       }
     }
 
-    responseArray = new String[responses.size()];
+    responseArray = new String[responses.size() + 1];
     for (int w = 0; w < responses.size(); ++w) {
       Pair<SensorType, ResolutionType> respToName = responses.get(w);
       responseArray[w] = ResponseUnits.getFilenameFromComponents(
           respToName.getFirst(), respToName.getSecond());
     }
-    Arrays.sort(responseArray, String::compareToIgnoreCase);
+    // add an extra line here, for the custom response loading option, not part of sorted list
+    responseArray[responseArray.length - 1] =  "Load external RESP file...";
+    // sort everything except that last entry, and ignore case in doing so
+    Arrays.sort(responseArray, 0, responseArray.length - 1, String::compareToIgnoreCase);
+
   }
 
   public static JSpinner timePickerFactory(Date start, Date end) {
@@ -409,13 +413,10 @@ public class InputPanel
       if (event.getSource() == resp) {
         // don't need a new thread because resp loading is pretty prompt
         // create new array with extra entry for a new string to load custom response
-        String[] nameArray = new String[responseArray.length + 1];
-        System.arraycopy(responseArray, 0, nameArray, 0, responseArray.length);
-        nameArray[nameArray.length - 1] =  "Load external RESP file...";
 
         int index = lastRespIndex;
         if (lastRespIndex < 0) {
-          index = nameArray.length - 1;
+          index = responseArray.length - 1;
         }
 
         JDialog dialog = new JDialog();
@@ -424,8 +425,8 @@ public class InputPanel
             "Select a response to load:",
             "RESP File Selection",
             JOptionPane.PLAIN_MESSAGE,
-            null, nameArray,
-            nameArray[index]);
+            null, responseArray,
+            responseArray[index]);
 
         final String resultStr = (String) result;
         // did user cancel operation?
@@ -434,7 +435,7 @@ public class InputPanel
         }
 
         // ignore case when sorting embeds -- sorting of the enums ignores case too
-        lastRespIndex = Arrays.binarySearch(responseArray, resultStr, String::compareToIgnoreCase);
+        lastRespIndex = Arrays.binarySearch(responseArray, 0, responseArray.length-1, resultStr, String::compareToIgnoreCase);
 
         // is the loaded string one of the embedded response files?
         // if it is, then we can get the enums of its name and load from them

--- a/src/main/java/asl/sensor/gui/InputPanel.java
+++ b/src/main/java/asl/sensor/gui/InputPanel.java
@@ -437,7 +437,7 @@ public class InputPanel
             fireStateChanged();
           } catch (IOException e) {
             // this really shouldn't be an issue with embedded responses
-            responseErrorPopup(resultStr);
+            responseErrorPopup(resultStr, e);
             e.printStackTrace();
             return;
           }
@@ -458,8 +458,8 @@ public class InputPanel
               respFileNames[i].setText(file.getName());
               clear.setEnabled(true);
               clearAll.setEnabled(true);
-            } catch (IOException e) {
-              responseErrorPopup(file.getName());
+            } catch (IOException | NullPointerException e) {
+              responseErrorPopup(file.getName(), e);
               e.printStackTrace();
               return;
             }
@@ -526,10 +526,13 @@ public class InputPanel
     }
   }
 
-  private void responseErrorPopup(String filename) {
+  private void responseErrorPopup(String filename, Exception e) {
     JDialog errorBox = new JDialog();
     String errorMsg = "Error while loading in response file:\n" + filename
-        + "\nCheck that file exists and is formatted correctly.";
+        + "\nCheck that file exists and is formatted correctly.\n"
+        + "Here is the error that was produced during the scan "
+        + "(check terminal for more detail):\n"
+        + e.getMessage() + "\nThrown at: " + e.getStackTrace()[0];
     JOptionPane.showMessageDialog(errorBox, errorMsg, "Response Loading Error",
         JOptionPane.ERROR_MESSAGE);
   }


### PR DESCRIPTION
STS2HGgen3 should _not_ come before STS2gen3 in the list; string comparator for the response name list is now case-insensitive in order to allow this.
Response loading would fail because binary search is undefined on an unsorted list, and list was considered unsorted by the standards of the default (case-sensitive) string comparator.