### PR TITLE
Submodules are now dependency of compilejar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,4 @@
 [submodule "asl-java-utils"]
 	path = asl-java-utils
 	url = git@code.usgs.gov:asl/asl-java-utils.git
+	branch = master

--- a/build.gradle
+++ b/build.gradle
@@ -118,4 +118,5 @@ task gitSubmodule(type: Exec) {
 }
 
 build.dependsOn copyJar, copyServerJar, gitSubmodule
+compileJava.dependsOn(gitSubmodule)
 processTestResources.dependsOn gitSubmodule


### PR DESCRIPTION
This wasn't an issue before the switch to using java utils as a separate library, because the test data was only required for testing, not for compilation.